### PR TITLE
#text onchange -> oninput

### DIFF
--- a/trypandoc.js
+++ b/trypandoc.js
@@ -328,7 +328,7 @@ function enableControlIf(ident, enable) {
     setFormFromParams();
 
     document.getElementById("convert").onclick = convert;
-    document.getElementById("from").onchange = (e) => {
+    document.getElementById("from").oninput = (e) => {
       params.from = e.target.value;
       convert();
     }


### PR DESCRIPTION
required so that it `params.text` is up to date, as onchange only fires onblur