### PR TITLE
paramsFromURL: merge with default params

### DIFF
--- a/trypandoc.js
+++ b/trypandoc.js
@@ -152,7 +152,8 @@ function paramsFromURL() {
   if (window.location.search.length > 0) {
     const query = new URLSearchParams(window.location.search);
     const rawparams = query.get("params");
-    params = JSON.parse(rawparams);
+    // `rawparams` may be a subset of required params
+    params = {...params, ...JSON.parse(rawparams)};
   }
 }
 


### PR DESCRIPTION
So that eg https://pandoc.org/try/?params={"to":"html5","from":"commonmark_x"} is possible.