### PR TITLE
Wrap lines in output

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ p.version { color: #555; }
 .controls {  display: flex; flex-wrap: wrap; justify-content: space-between; column-gap: 6pt; }
 #frompane { flex: 1; padding: 3pt; }
 #topane { flex: 1; padding: 3pt; }
-#topane pre { margin-top: 0; min-height: 65vh; width: 44vw; max-width: 44vw; overflow: auto; }
+#topane pre { margin-top: 0; min-height: 65vh; width: 44vw; max-width: 44vw; overflow: auto; white-space: pre-wrap; }
 #text {margin-top: 0; padding-top: 0;}
 button#convert { vertical-align: bottom; background-color: red; font-weight: bold; color: white; border: none; border-radius: 4px; }
 .disabled { color: #aaa; }


### PR DESCRIPTION
Wrap lines in output (only noticable for json)

<img width="70%" alt="Screenshot 2023-08-05 at 9 33 01 PM" src="https://github.com/jgm/trypandoc/assets/17685332/1555fbca-f4d3-4be5-9b37-4e6ded7b8214">
